### PR TITLE
Adds ability to pass conditional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ end
 Nothing will happen at all until February 4th, at which point the gem will
 raise an error whenever this class is loaded until someone deals with it.
 
+You may also pass a condition:
+
+``` ruby
+class User < ApplicationRecord
+  TodoOrDie(
+    "delete after 1 million users",
+    if: User.size > 1000000,
+  )
+  def is_one_millionth_user?
+    id == 1000000
+  end
+end
+```
+
 ### What kind of error?
 
 It depends on whether you're using [Rails](https://rubyonrails.org) or not.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ end
 Nothing will happen at all until February 4th, at which point the gem will
 raise an error whenever this class is loaded until someone deals with it.
 
-You may also pass a condition:
+You may also pass a condition, either as boolean or in proc/lambda form:
 
 ``` ruby
 class User < ApplicationRecord

--- a/lib/todo_or_die.rb
+++ b/lib/todo_or_die.rb
@@ -39,12 +39,13 @@ module TodoOrDie
 end
 
 # The main event
-def TodoOrDie(message, by: nil, if: true) # rubocop:disable Naming/MethodName
+def TodoOrDie(message, by: nil, if: -> { true }) # rubocop:disable Naming/MethodName
   if by
     by_passed = true
   end
 
-  if binding.local_variable_get(:if)
+  condition = binding.local_variable_get(:if)
+  if condition.respond_to?(:call) && condition.call || condition == true
     due_at = by&.to_time || Time.now
 
     if Time.now >= due_at

--- a/test/todo_or_die_test.rb
+++ b/test/todo_or_die_test.rb
@@ -92,14 +92,14 @@ class TodoOrDieTest < UnitTest
     Timecop.travel(Date.civil(2200, 2, 4))
 
     assert_raises(TodoOrDie::OverdueTodo) {
-      TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 4)
+      TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: -> { 2 + 2 == 4 })
     }
   end
 
   def test_not_due_and_if_condition_is_true_does_not_blow_up
     Timecop.travel(Date.civil(2100, 2, 4))
 
-    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 4)
+    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: -> { 2 + 2 == 4 })
 
     # 🦗 sounds
   end
@@ -107,14 +107,14 @@ class TodoOrDieTest < UnitTest
   def test_due_and_if_condition_is_false_does_not_blow_up
     Timecop.travel(Date.civil(2200, 2, 4))
 
-    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 5)
+    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: -> { 2 + 2 == 5 })
 
     # 🦗 sounds
   end
 
   def test_by_not_passed_and_if_condition_is_true_blows_up
     error = assert_raises(TodoOrDie::OverdueTodo) {
-      TodoOrDie("Check your math", if: 2 + 2 == 4)
+      TodoOrDie("Check your math", if: -> { 2 + 2 == 4 })
     }
 
     assert_equal <<~MSG, error.message
@@ -123,8 +123,20 @@ class TodoOrDieTest < UnitTest
   end
 
   def test_by_not_passed_and_if_condition_false_does_not_blow_up
-    TodoOrDie("Check your math", if: 2 + 2 == 5)
+    TodoOrDie("Check your math", if: -> { 2 + 2 == 5 })
 
     # 🦗 sounds
+  end
+
+  def test_by_not_passed_and_if_condition_is_false_boolean_does_not_blow_up
+    TodoOrDie("Check your math", if: false)
+
+    # 🦗 sounds
+  end
+
+  def test_by_not_passed_and_if_condition_is_true_boolean_blows_up
+    assert_raises(TodoOrDie::OverdueTodo) {
+      TodoOrDie("Check your math", if: true)
+    }
   end
 end

--- a/test/todo_or_die_test.rb
+++ b/test/todo_or_die_test.rb
@@ -87,4 +87,44 @@ class TodoOrDieTest < UnitTest
   def test_has_version
     assert TodoOrDie::VERSION
   end
+
+  def test_due_and_if_condition_is_true_blows_up
+    Timecop.travel(Date.civil(2200, 2, 4))
+
+    assert_raises(TodoOrDie::OverdueTodo) {
+      TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 4)
+    }
+  end
+
+  def test_not_due_and_if_condition_is_true_does_not_blow_up
+    Timecop.travel(Date.civil(2100, 2, 4))
+
+    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 4)
+
+    # 🦗 sounds
+  end
+
+  def test_due_and_if_condition_is_false_does_not_blow_up
+    Timecop.travel(Date.civil(2200, 2, 4))
+
+    TodoOrDie("Check your math", by: Date.civil(2200, 2, 4), if: 2 + 2 == 5)
+
+    # 🦗 sounds
+  end
+
+  def test_by_not_passed_and_if_condition_is_true_blows_up
+    error = assert_raises(TodoOrDie::OverdueTodo) {
+      TodoOrDie("Check your math", if: 2 + 2 == 4)
+    }
+
+    assert_equal <<~MSG, error.message
+      TODO: "Check your math" has met the conditions to be acted upon. Do it!
+    MSG
+  end
+
+  def test_by_not_passed_and_if_condition_false_does_not_blow_up
+    TodoOrDie("Check your math", if: 2 + 2 == 5)
+
+    # 🦗 sounds
+  end
 end


### PR DESCRIPTION
* As requested in this issue https://github.com/searls/todo_or_die/issues/5, this commit
makes it possible to pass an `if` keyword argument to `TodoOrDie`. A
user can use only `if`, only `by`, or both.