### PR TITLE
Fix NoMethodError (undefined method `parse' for Time:Class)

### DIFF
--- a/lib/todo_or_die.rb
+++ b/lib/todo_or_die.rb
@@ -1,5 +1,6 @@
 require "todo_or_die/version"
 require "todo_or_die/overdue_error"
+require "time" unless Time.respond_to? :parse
 
 # The namespace
 module TodoOrDie


### PR DESCRIPTION
When called on a place where "time" has not been required, it would cause Time.parse to raise NoMethodError.